### PR TITLE
Add blank line after an explicit markup block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -547,6 +547,7 @@ which will be the focus of path manipulation in this tutorial.
   >>> # make file executable with mode bits
   >>> readme.chmod(0o755)
   >>> # ^ note that octal notation is must be explicite.
+
 Again, check out the documentation for more info. pathlib.Path_. Since
 ``pathlib`` came out, more and more builtin functions and functions in
 the standard library that take a path name as a string argument can also


### PR DESCRIPTION
Reviewing the document in Vim I found an error in the line 550 due there isn't a blank line after the explicit markup block closed in line 549. This PR solves this issue.